### PR TITLE
feat: 资产管理输入时保留类别，并增加 Enter 快捷键

### DIFF
--- a/src/Capital/AddAssetItemForm.tsx
+++ b/src/Capital/AddAssetItemForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Stack, Group, Title, TextInput, NumberInput, Button, Select } from '@mantine/core';
 import { Category } from './types';
 import { sectionCss } from './styles';
@@ -12,22 +12,31 @@ export const AddAssetItemForm = ({ categories, onAdd }: AddAssetItemFormProps) =
     const [newItemName, setNewItemName] = useState('');
     const [newItemCategory, setNewItemCategory] = useState('');
     const [newItemAmount, setNewItemAmount] = useState<number | string>(0);
+    const nameInputRef = useRef<HTMLInputElement>(null);
 
     const handleAdd = () => {
         if (!newItemName.trim() || !newItemCategory) return;
         const amount = typeof newItemAmount === 'number' ? newItemAmount : parseFloat(newItemAmount) || 0;
         onAdd(newItemName.trim(), newItemCategory, amount);
         setNewItemName('');
-        setNewItemCategory('');
         setNewItemAmount(0);
+        nameInputRef.current?.focus();
     };
 
     return (
         <div className={sectionCss}>
             <Title order={4} mb="md">添加资产项</Title>
-            <Stack gap="sm">
+            <Stack
+                gap="sm"
+                component="form"
+                onSubmit={(event) => {
+                    event.preventDefault();
+                    handleAdd();
+                }}
+            >
                 <Group gap="xs" align="end">
                     <TextInput
+                        ref={nameInputRef}
                         label="名称"
                         placeholder="例如：工商银行"
                         value={newItemName}
@@ -52,7 +61,7 @@ export const AddAssetItemForm = ({ categories, onAdd }: AddAssetItemFormProps) =
                     thousandSeparator=","
                     decimalScale={2}
                 />
-                <Button onClick={handleAdd} fullWidth>
+                <Button type="submit" fullWidth>
                     添加资产项
                 </Button>
             </Stack>


### PR DESCRIPTION
### Motivation
- Enable fast batch entry of many assets in the same category by preserving the selected category after each add. 
- Improve speed of entry by allowing `Enter` to submit the add form and returning focus to the name field for the next item.

### Description
- Updated `src/Capital/AddAssetItemForm.tsx` to keep the category value after adding an asset by removing the category reset. 
- Switched the input container to a form by setting `Stack`'s `component="form"` and adding an `onSubmit` handler that calls `handleAdd` to support `Enter`-key submission. 
- Added a `nameInputRef` via `useRef` and focus it after submit, and changed the add `Button` to `type="submit"` to integrate with the form submit flow. 
- Changes are implemented using `useRef`/`useState` and do not alter external APIs; only `src/Capital/AddAssetItemForm.tsx` was modified.

### Testing
- Ran `yarn lint src/Capital/AddAssetItemForm.tsx` which succeeded. 
- Ran `yarn lint-type` (TypeScript checks) which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a950498af8832d99b9e522d92f7720)