### PR TITLE
ci: 合入 main 自动部署 github pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,57 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: yarn
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build project
+        run: yarn build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Motivation
- Add CI to automatically build and publish the site to GitHub Pages when changes land on `main` and to allow manual runs via `workflow_dispatch`.

### Description
- Add `.github/workflows/deploy-pages.yml` which triggers on `push` to `main` and `workflow_dispatch` and configures `contents: read`, `pages: write`, and `id-token: write` permissions with concurrency control.
- Implement a `build` job that checks out the repo, sets up Node.js 24 with `actions/setup-node@v4`, enables Corepack, runs `yarn install --immutable` and `yarn build`, then uploads the `dist` directory using `actions/upload-pages-artifact@v3` after `actions/configure-pages@v5`.
- Implement a `deploy` job that depends on `build` and runs `actions/deploy-pages@v4` to publish the uploaded artifact to the `github-pages` environment.

### Testing
- Ran `yarn build` in the repository and the build completed successfully producing the `dist` output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa1f96dca8832d93179a431110912b)