### PR TITLE
chore: 升级到 Vite 8 并同步更新相关依赖

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,15 +59,15 @@
         "@types/react": "^19.2.6",
         "@types/react-dom": "^19.2.3",
         "@types/three": "^0.181.0",
-        "@vitejs/plugin-react": "^5.1.1",
+        "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^9.39.1",
         "gh-pages": "^6.3.0",
         "glob": "^12.0.0",
         "husky": "^9.1.7",
         "knip": "^5.70.0",
         "typescript": "^5.9.3",
-        "unocss": "^66.5.10",
-        "vite": "npm:rolldown-vite@latest"
+        "unocss": "^66.6.7",
+        "vite": "^8.0.1"
       },
       "engines": {
         "node": ">=24.11.0"

--- a/package.json
+++ b/package.json
@@ -72,14 +72,14 @@
     "@types/react": "^19.2.6",
     "@types/react-dom": "^19.2.3",
     "@types/three": "^0.181.0",
-    "@vitejs/plugin-react": "^5.1.1",
+    "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^9.39.1",
     "gh-pages": "^6.3.0",
     "glob": "^12.0.0",
     "husky": "^9.1.7",
     "knip": "^5.70.0",
     "typescript": "^5.9.3",
-    "unocss": "^66.5.10",
-    "vite": "npm:rolldown-vite@latest"
+    "unocss": "^66.6.7",
+    "vite": "^8.0.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
             "dom.iterable",
         ],
         "sourceMap": true,
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "baseUrl": ".",
         "paths": {
             "@/*": ["src/*"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'vite';
 import { resolve, extname } from 'path';
 import { readdirSync } from 'fs';
 import uno from 'unocss/vite';
-// @ts-expect-error
 import react from '@vitejs/plugin-react';
 
 const getInput = () => {


### PR DESCRIPTION
### Motivation
- 将项目升级到 Vite 8 以跟随 Vite 的主要版本更新并使用新版插件的类型支持和优化。 
- 同步升级相关构建插件以避免与 Vite 8 的不兼容问题并改善开发体验。 

### Description
- 将 `vite` 从 `npm:rolldown-vite@latest` 切换为正式的 `^8.0.1`，并在 `package.json`/`package-lock.json` 根级别同步更新了该版本范围。 
- 升级 `@vitejs/plugin-react` 到 `^6.0.1` 和 `unocss` 到 `^66.6.7`，并在 `vite.config.ts` 中移除了原先为绕过类型错误添加的 `// @ts-expect-error`。 
- 将 `tsconfig.json` 中的 `moduleResolution` 从 `node` 调整为 `bundler` 以兼容新版插件的类型解析。 
- 仅更新了根级依赖声明与配置变更，未在当前环境下重新完整生成 lockfile。 

### Testing
- 已运行 `npm run lint`，ESLint 执行成功。 
- 已运行 `npm run lint-type`（即 `tsc`），类型检查通过。 
- 运行 `npm run build` 在当前环境失败：现有 `node_modules` 中缺少旧别名包的原生绑定（`@rolldown/binding-...`），且当前环境对 npm registry 的访问受限，导致无法重新安装依赖并完整验证构建。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb9b4a62b8832d815ee6ca8e4ffa5e)